### PR TITLE
Feat: Hokeys to navigate between tabs and result sets

### DIFF
--- a/src/renderer/components/Workspace.vue
+++ b/src/renderer/components/Workspace.vue
@@ -556,7 +556,9 @@ export default {
          selectTab,
          newTab,
          removeTab,
-         updateTabs
+         updateTabs,
+         selectNextTab,
+         selectPrevTab
       } = workspacesStore;
 
       return {
@@ -568,7 +570,9 @@ export default {
          selectTab,
          newTab,
          removeTab,
-         updateTabs
+         updateTabs,
+         selectNextTab,
+         selectPrevTab
       };
    },
    data () {
@@ -669,6 +673,22 @@ export default {
             const currentTab = this.getSelectedTab();
             if (currentTab)
                this.closeTab(currentTab);
+         }
+
+         // select next tab
+         if (e.altKey && (e.ctrlKey || e.metaKey) && e.key === 'ArrowRight')
+            this.selectNextTab({ uid: this.connection.uid });
+
+         // select prev tab
+         if (e.altKey && (e.ctrlKey || e.metaKey) && e.key === 'ArrowLeft')
+            this.selectPrevTab({ uid: this.connection.uid });
+
+         // select tab by index (range 1-9). CTRL|CMD number
+         if ((e.ctrlKey || e.metaKey) && !e.altKey && e.keyCode >= 49 && e.keyCode <= 57) {
+            const newIndex = parseInt(e.key) - 1;
+
+            if (this.workspace.tabs[newIndex])
+               this.selectTab({ uid: this.connection.uid, tab: this.workspace.tabs[newIndex].uid });
          }
       },
       openAsPermanentTab (tab) {

--- a/src/renderer/scss/themes/dark-theme.scss
+++ b/src/renderer/scss/themes/dark-theme.scss
@@ -231,7 +231,8 @@
         .td {
           border-color: $body-bg-dark;
 
-          &:focus {
+          &:focus,
+          &.selected {
             box-shadow: inset 0 0 0 2px darken($body-font-color-dark, 40%);
             background-color: rgba($color: #000, $alpha: 0.3);
           }

--- a/src/renderer/scss/themes/light-theme.scss
+++ b/src/renderer/scss/themes/light-theme.scss
@@ -252,7 +252,8 @@
         .td {
           border-color: $body-bg;
 
-          &:focus {
+          &:focus,
+          &.selected {
             box-shadow: inset 0 0 0 2px lighten($body-font-color, 10%);
             background-color: $body-font-color-dark;
           }

--- a/src/renderer/stores/workspaces.js
+++ b/src/renderer/stores/workspaces.js
@@ -609,6 +609,26 @@ export const useWorkspacesStore = defineStore('workspaces', {
             : workspace
          );
       },
+      selectNextTab ({ uid }) {
+         const workspace = this.workspaces.find(workspace => workspace.uid === uid);
+
+         let newIndex = workspace.tabs.findIndex(tab => tab.selected || tab.uid === workspace.selectedTab) + 1;
+
+         if (newIndex > workspace.tabs.length -1)
+            newIndex = 0;
+
+         this.selectTab({ uid, tab: workspace.tabs[newIndex].uid });
+      },
+      selectPrevTab ({ uid }) {
+         const workspace = this.workspaces.find(workspace => workspace.uid === uid);
+
+         let newIndex = workspace.tabs.findIndex(tab => tab.selected || tab.uid === workspace.selectedTab) - 1;
+
+         if (newIndex < 0)
+            newIndex = workspace.tabs.length -1;
+
+         this.selectTab({ uid, tab: workspace.tabs[newIndex].uid });
+      },
       updateTabs ({ uid, tabs }) {
          this.workspaces = this.workspaces.map(workspace => workspace.uid === uid
             ? { ...workspace, tabs }


### PR DESCRIPTION
With this PR I want to share my obsession for productivity hotkeys.

# Available scopes

## Workspace Navigation Tabs
* Windows
  * `Ctrl + Alt + Right`: Navigate to next tab
  * `Ctrl + Alt + Left`: Navigate to previous tab
  * `Ctrl + [number 1-9]` Navigate to the tab at index [number]
* Mac OS
  * `Cmd + Alt + Right`: Navigate to next tab
  * `Cmd + Alt + Left`: Navigate to previous tab
  * `Cmd + [number 1-9]` Navigate to the tab at index [number]

## Workspace Table Result sets
* `Arrow Keys`: Navigate between cells and rows
* `Tab` or `Shift + tab`: Navigate between cells in a single row
* `Enter`: Start editing the selected table cell
  * `Esc`: Undo cell editing. No data will be saved
  * `Enter`: Save the modified cell data

Hope you enjoy it!