### PR TITLE
fix: 'Insert rows' form closes when lost focus

### DIFF
--- a/src/renderer/components/ModalFakerRows.vue
+++ b/src/renderer/components/ModalFakerRows.vue
@@ -1,7 +1,7 @@
 <template>
    <Teleport to="#window-content">
       <div class="modal active">
-         <a class="modal-overlay" @click.stop="closeModal" />
+         <a class="modal-overlay" />
          <div ref="trapRef" class="modal-container p-0">
             <div class="modal-header pl-2">
                <div class="modal-title h6">


### PR DESCRIPTION
fix #329 