### PR TITLE
fix: Cannot update column value with composite primary key and JSON column #916

### DIFF
--- a/src/common/libs/sqlUtils.ts
+++ b/src/common/libs/sqlUtils.ts
@@ -8,6 +8,7 @@ import customizations from '../customizations';
 import { ClientCode } from '../interfaces/antares';
 import { getArrayDepth } from './getArrayDepth';
 import hexToBinary, { HexChar } from './hexToBinary';
+import * as antares from 'common/interfaces/antares';
 
 /**
  * Escapes a string fo SQL use
@@ -208,4 +209,21 @@ export const jsonToSqlInsert = (args: {
       insertsString += insertStmt+';';
 
    return insertsString;
+};
+
+export const formatJsonForSqlWhere = (jsonValue: object, clientType: antares.ClientCode) => {
+   const formattedValue = JSON.stringify(jsonValue);
+
+   switch (clientType) {
+      case 'mysql':
+         return ` = CAST('${formattedValue}' AS JSON)`;
+      case 'maria':
+         return ` = '${formattedValue}'`;
+      case 'pg':
+         return `::text = '${formattedValue}'`;
+      case 'firebird':
+      case 'sqlite':
+      default:
+         return ` = '${formattedValue}'`;
+   }
 };

--- a/src/main/ipc-handlers/tables.ts
+++ b/src/main/ipc-handlers/tables.ts
@@ -3,7 +3,7 @@ import { ARRAY, BIT, BLOB, BOOLEAN, DATE, DATETIME, FLOAT, LONG_TEXT, NUMBER, TE
 import * as antares from 'common/interfaces/antares';
 import { InsertRowsParams } from 'common/interfaces/tableApis';
 import { fakerCustom } from 'common/libs/fakerCustom';
-import { sqlEscaper } from 'common/libs/sqlUtils';
+import { formatJsonForSqlWhere, sqlEscaper } from 'common/libs/sqlUtils';
 import { ipcMain } from 'electron';
 import * as fs from 'fs';
 import * as moment from 'moment';
@@ -233,26 +233,12 @@ export default (connections: Record<string, antares.Client>) => {
 
             for (const key in orgRow) {
                if (typeof orgRow[key] === 'string')
-                  orgRow[key] = `'${orgRow[key]}'`;
-               else if (typeof orgRow[key] === 'object') {
-                  switch (connections[params.uid]._client) {
-                     case 'mysql':
-                        orgRow[key] = `CAST('${JSON.stringify(orgRow[key])}' AS JSON)`;
-                        break;
-                     case 'maria':
-                        orgRow[key] = `'${JSON.stringify(orgRow[key])}'`;
-                        break;
-                     case 'pg':
-                        orgRow[key] = `::text='${JSON.stringify(orgRow[key])}'`;
-                        break;
-                     case 'firebird':
-                     case 'sqlite':
-                  }
-               }
-
-               if (orgRow[key] === null)
+                  orgRow[key] = ` = '${orgRow[key]}'`;
+               else if (typeof orgRow[key] === 'object' && orgRow[key] !== null)
+                  orgRow[key] = formatJsonForSqlWhere(orgRow[key], connections[params.uid]._client);
+               else if (orgRow[key] === null)
                   orgRow[key] = `IS ${orgRow[key]}`;
-               else if (!String(orgRow[key]).includes('::text='))
+               else
                   orgRow[key] = `= ${orgRow[key]}`;
             }
 

--- a/src/main/ipc-handlers/tables.ts
+++ b/src/main/ipc-handlers/tables.ts
@@ -235,12 +235,24 @@ export default (connections: Record<string, antares.Client>) => {
                if (typeof orgRow[key] === 'string')
                   orgRow[key] = `'${orgRow[key]}'`;
                else if (typeof orgRow[key] === 'object') {
-                  orgRow[key] = `CAST('${JSON.stringify(orgRow[key])}' AS JSON)`;
+                  switch (connections[params.uid]._client) {
+                     case 'mysql':
+                        orgRow[key] = `CAST('${JSON.stringify(orgRow[key])}' AS JSON)`;
+                        break;
+                     case 'maria':
+                        orgRow[key] = `'${JSON.stringify(orgRow[key])}'`;
+                        break;
+                     case 'pg':
+                        orgRow[key] = `::text='${JSON.stringify(orgRow[key])}'`;
+                        break;
+                     case 'firebird':
+                     case 'sqlite':
+                  }
                }
 
                if (orgRow[key] === null)
                   orgRow[key] = `IS ${orgRow[key]}`;
-               else
+               else if (!String(orgRow[key]).includes('::text='))
                   orgRow[key] = `= ${orgRow[key]}`;
             }
 

--- a/src/main/ipc-handlers/tables.ts
+++ b/src/main/ipc-handlers/tables.ts
@@ -234,6 +234,9 @@ export default (connections: Record<string, antares.Client>) => {
             for (const key in orgRow) {
                if (typeof orgRow[key] === 'string')
                   orgRow[key] = `'${orgRow[key]}'`;
+               else if (typeof orgRow[key] === 'object') {
+                  orgRow[key] = `CAST('${JSON.stringify(orgRow[key])}' AS JSON)`;
+               }
 
                if (orgRow[key] === null)
                   orgRow[key] = `IS ${orgRow[key]}`;


### PR DESCRIPTION
Fixes #916


I've tested the update on MySQL and PostgreSQL, as these are the databases I currently have available.

For MariaDB, JSON data is stored as LONGTEXT, so the update should work as long as the data is saved with the same formatting.

As for SQLite and Firebird, it appears they do not natively support JSON columns.