### PR TITLE
refactor: allow system-wide installations for nsis

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,9 @@
       "license": "./LICENSE",
       "installerIcon": "assets/icon.ico",
       "uninstallerIcon": "assets/icon.ico",
-      "installerHeader": "assets/icon.ico"
+      "installerHeader": "assets/icon.ico",
+      "oneClick": false,
+      "perMachine": false
     },
     "portable": {
       "artifactName": "${productName}-${version}-portable.exe"


### PR DESCRIPTION
This allows a system-wide installation for the windows nsis installer. I've tested this with a local build and unattended installation on a windows 11 system.

This closes #1011
