### PR TITLE
feat: add insomnia-like saved queries panel with auto-save

### DIFF
--- a/src/renderer/components/TheScratchpad.vue
+++ b/src/renderer/components/TheScratchpad.vue
@@ -209,10 +209,10 @@ const selectedNote = ref(null);
 
 const noteTags: ComputedRef<{code: TagCode; name: string}[]> = computed(() => [
    { code: 'note', name: t('application.note') },
-   { code: 'todo', name: 'TODO' },
-   { code: 'query', name: 'Query' }
+   { code: 'todo', name: 'TODO' }
 ]);
 const filteredNotes = computed(() => connectionNotes.value.filter(n => (
+   n.type !== 'query' &&
    (n.type === selectedTag.value || selectedTag.value === 'all') &&
    (n.cUid === localConnection.value || localConnection.value === null) &&
    (!n.isArchived || showArchived.value) &&
@@ -291,7 +291,8 @@ const selectQuery = (query: string) => {
          uid: selectedWorkspace.value,
          type: 'query',
          content: query,
-         schema: workspace.breadcrumbs.schema
+         schema: workspace.breadcrumbs.schema,
+         elementType: selectedTab.elementType
       });
    }
    else {

--- a/src/renderer/components/Workspace.vue
+++ b/src/renderer/components/Workspace.vue
@@ -47,7 +47,7 @@
                            :size="18"
                         />
                         <span>
-                           <span>{{ cutText(element.elementName || element.content || 'Query', 20, true) }} #{{ element.index }}</span>
+                           <span>{{ cutText(element.elementName || element.content || 'Query', 20, true) }}</span>
                            <span
                               class="btn btn-clear"
                               :title="t('general.close')"
@@ -654,6 +654,7 @@ import WorkspaceTabTable from '@/components/WorkspaceTabTable.vue';
 import { useFilters } from '@/composables/useFilters';
 import Connection from '@/ipc-api/Connection';
 import { useConsoleStore } from '@/stores/console';
+import { getSavedQueryMarker, useSavedQueriesStore } from '@/stores/savedQueries';
 import { useWorkspacesStore, WorkspaceTab } from '@/stores/workspaces';
 
 import WorkspaceTabNewMaterializedView from './WorkspaceTabNewMaterializedView.vue';
@@ -663,6 +664,7 @@ const { t } = useI18n();
 
 const { cutText } = useFilters();
 const workspacesStore = useWorkspacesStore();
+const savedQueriesStore = useSavedQueriesStore();
 
 const { getSelected: selectedWorkspace } = storeToRefs(workspacesStore);
 
@@ -740,7 +742,23 @@ watch(queryTabs, (newVal, oldVal) => {
 });
 
 const addQueryTab = () => {
-   newTab({ uid: props.connection.uid, type: 'query', schema: workspace.value.breadcrumbs.schema });
+   const newQueryItem = savedQueriesStore.addQuery({
+      connectionUid: props.connection.uid,
+      name: t('database.newQuery'),
+      sql: '',
+      schema: workspace.value.breadcrumbs.schema,
+      database: workspace.value.database
+   });
+
+   newTab({
+      uid: props.connection.uid,
+      type: 'query',
+      content: '',
+      elementName: newQueryItem.name,
+      elementType: getSavedQueryMarker(newQueryItem.uid),
+      autorun: false,
+      schema: newQueryItem.schema || workspace.value.breadcrumbs.schema
+   });
 };
 
 const getSelectedTab = () => {

--- a/src/renderer/components/WorkspaceExploreBar.vue
+++ b/src/renderer/components/WorkspaceExploreBar.vue
@@ -53,7 +53,25 @@
                </div>
             </span>
          </div>
-         <div class="workspace-explorebar-search">
+         <div v-if="workspace.connectionStatus === 'connected'" class="workspace-explorebar-tabs">
+            <button
+               class="tab-btn"
+               :class="{ active: activeTab === 'database' }"
+               @click="activeTab = 'database'"
+            >
+               <BaseIcon icon-name="mdiDatabase" :size="14" />
+               <span>{{ t('connection.databases') }}</span>
+            </button>
+            <button
+               class="tab-btn"
+               :class="{ active: activeTab === 'queries' }"
+               @click="activeTab = 'queries'"
+            >
+               <BaseIcon icon-name="mdiBookmarkMultiple" :size="14" />
+               <span>{{ t('database.savedQueries') }}</span>
+            </button>
+         </div>
+         <div v-if="activeTab === 'database'" class="workspace-explorebar-search">
             <div v-if="workspace.connectionStatus === 'connected'" class="input-group has-icon-right">
                <div
                   class="input-group-addon px-1 py-0 p-vcentered c-hand"
@@ -84,7 +102,11 @@
                />
             </div>
          </div>
-         <div class="workspace-explorebar-body" @click="explorebar.focus()">
+         <div
+            v-if="activeTab === 'database'"
+            class="workspace-explorebar-body"
+            @click="explorebar.focus()"
+         >
             <WorkspaceExploreBarSchema
                v-for="db of filteredSchemas"
                :key="db.name"
@@ -96,6 +118,11 @@
                @show-table-context="openTableContext"
                @show-misc-context="openMiscContext"
                @show-misc-folder-context="openMiscFolderContext"
+            />
+         </div>
+         <div v-else class="workspace-explorebar-body">
+            <WorkspaceExploreSavedQueries
+               :connection-uid="connection.uid"
             />
          </div>
       </div>
@@ -143,7 +170,7 @@
          :selected-schema="selectedSchema"
          :context-event="miscContextEvent"
          @open-create-view-tab="openCreateElementTab('view')"
-         @open-create-materializedView-tab="openCreateElementTab('materialized-view')"
+         @open-create-materialized-view-tab="openCreateElementTab('materialized-view')"
          @open-create-trigger-tab="openCreateElementTab('trigger')"
          @open-create-trigger-function-tab="openCreateElementTab('trigger-function')"
          @open-create-routine-tab="openCreateElementTab('routine')"
@@ -169,6 +196,7 @@ import MiscFolderContext from '@/components/WorkspaceExploreBarMiscFolderContext
 import WorkspaceExploreBarSchema from '@/components/WorkspaceExploreBarSchema.vue';
 import DatabaseContext from '@/components/WorkspaceExploreBarSchemaContext.vue';
 import TableContext from '@/components/WorkspaceExploreBarTableContext.vue';
+import WorkspaceExploreSavedQueries from '@/components/WorkspaceExploreSavedQueries.vue';
 import Databases from '@/ipc-api/Databases';
 import Tables from '@/ipc-api/Tables';
 import Views from '@/ipc-api/Views';
@@ -228,6 +256,7 @@ const selectedTable = ref(null);
 const selectedMisc = ref(null);
 const searchTerm = ref('');
 const searchMethod: Ref<'elements' | 'schemas'> = ref('elements');
+const activeTab: Ref<'database' | 'queries'> = ref('database');
 
 const workspace = computed(() => {
    return getWorkspace(props.connection.uid);
@@ -576,6 +605,49 @@ const toggleSearchMethod = () => {
          font-size: 0.6rem;
          height: 1.2rem;
          line-height: 1rem;
+      }
+    }
+
+    .workspace-explorebar-tabs {
+      width: 100%;
+      display: flex;
+      padding: 0 0.1rem;
+      margin-bottom: 0.25rem;
+      gap: 2px;
+
+      .tab-btn {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.25rem;
+        padding: 0.3rem 0.4rem;
+        font-size: 0.65rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        border: none;
+        border-radius: $border-radius;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        opacity: 0.6;
+        transition: opacity 0.2s, background 0.2s;
+
+        &:hover {
+          opacity: 0.8;
+          background: var(--bg-color-light-dark);
+        }
+
+        &.active {
+          opacity: 1;
+          background: var(--bg-color-light-dark);
+        }
+
+        span {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
       }
     }
 

--- a/src/renderer/components/WorkspaceExploreSavedQueries.vue
+++ b/src/renderer/components/WorkspaceExploreSavedQueries.vue
@@ -1,0 +1,710 @@
+<template>
+   <div class="workspace-saved-queries">
+      <details
+         ref="accordion"
+         class="accordion"
+         :open="isExpanded"
+      >
+         <summary
+            class="accordion-header saved-queries-header"
+            @click.prevent="toggleExpanded"
+            @contextmenu.prevent="showHeaderContext"
+         >
+            <BaseIcon
+               class="icon"
+               icon-name="mdiChevronRight"
+               :size="18"
+            />
+            <BaseIcon
+               class="mr-1"
+               icon-name="mdiBookmarkMultiple"
+               :size="18"
+            />
+            <span class="saved-queries-title">{{ t('database.savedQueries') }}</span>
+            <span v-if="queryCount > 0" class="saved-queries-count">({{ queryCount }})</span>
+            <div class="saved-queries-tools">
+               <BaseIcon
+                  v-tooltip="{
+                     strategy: 'fixed',
+                     content: t('database.createNewQuery')
+                  }"
+                  class="c-hand"
+                  icon-name="mdiPlus"
+                  :size="16"
+                  @click.stop.prevent="createNewQuery"
+               />
+            </div>
+         </summary>
+         <div class="accordion-body">
+            <div v-if="queryCount === 0 && folderCount === 0" class="empty-state">
+               <small>{{ t('database.noSavedQueries') }}</small>
+            </div>
+            <ul v-else class="menu menu-nav pt-0 saved-queries-list">
+               <WorkspaceExploreSavedQueriesFolder
+                  v-for="folder in rootFolders"
+                  :key="folder.uid"
+                  :folder="folder"
+                  :connection-uid="connectionUid"
+                  :depth="0"
+                  @open-query="openQuery"
+                  @run-query="runQuery"
+                  @show-folder-context="showFolderContext"
+                  @show-query-context="showQueryContext"
+               />
+               <WorkspaceExploreSavedQueriesItem
+                  v-for="query in rootQueries"
+                  :key="query.uid"
+                  :query="query"
+                  :connection-uid="connectionUid"
+                  @open-query="openQuery"
+                  @run-query="runQuery"
+                  @show-context="showQueryContext"
+               />
+            </ul>
+         </div>
+      </details>
+
+      <BaseContextMenu
+         v-if="isHeaderContext"
+         :context-event="contextEvent"
+         @close-context="closeContext"
+      >
+         <div class="context-element" @click="createNewQuery">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiCodeBrackets"
+                  :size="18"
+               /> {{ t('database.newQuery') }}</span>
+         </div>
+         <div class="context-element" @click="createNewFolder">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiFolderPlus"
+                  :size="18"
+               /> {{ t('database.newFolder') }}</span>
+         </div>
+      </BaseContextMenu>
+
+      <BaseContextMenu
+         v-if="isFolderContext && selectedFolder"
+         :context-event="contextEvent"
+         @close-context="closeContext"
+      >
+         <div class="context-element" @click="createQueryInFolder">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiCodeBrackets"
+                  :size="18"
+               /> {{ t('database.newQuery') }}</span>
+         </div>
+         <div
+            v-if="canAddSubfolder"
+            class="context-element"
+            @click="createSubfolder"
+         >
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiFolderPlus"
+                  :size="18"
+               /> {{ t('database.newSubfolder') }}</span>
+         </div>
+         <div class="context-element" @click="startRenameFolder">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiRenameBox"
+                  :size="18"
+               /> {{ t('general.rename') }}</span>
+         </div>
+         <div class="context-element-divider" />
+         <div class="context-element" @click="confirmDeleteFolder">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiDeleteForever"
+                  :size="18"
+               /> {{ t('general.delete') }}</span>
+         </div>
+      </BaseContextMenu>
+
+      <BaseContextMenu
+         v-if="isQueryContext && selectedQuery"
+         :context-event="contextEvent"
+         @close-context="closeContext"
+      >
+         <div class="context-element" @click="runSelectedQuery">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiPlay"
+                  :size="18"
+               /> {{ t('database.runQuery') }}</span>
+         </div>
+         <div class="context-element" @click="openSelectedQuery">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiOpenInNew"
+                  :size="18"
+               /> {{ t('database.openInNewTab') }}</span>
+         </div>
+         <div class="context-element-divider" />
+         <div class="context-element" @click="startRenameQuery">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiRenameBox"
+                  :size="18"
+               /> {{ t('general.rename') }}</span>
+         </div>
+         <div class="context-element" @click="duplicateSelectedQuery">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiContentDuplicate"
+                  :size="18"
+               /> {{ t('general.duplicate') }}</span>
+         </div>
+         <div class="context-element-divider" />
+         <div class="context-element context-element-submenu">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiFolderMove"
+                  :size="18"
+               /> {{ t('general.moveTo') }}</span>
+            <BaseIcon
+               class="submenu-arrow"
+               icon-name="mdiChevronRight"
+               :size="18"
+            />
+            <div class="context-submenu">
+               <div
+                  class="context-element"
+                  :class="{ disabled: selectedQuery.folderId === null }"
+                  @click="moveQueryToFolder(null)"
+               >
+                  <span class="d-flex">{{ t('general.root') }}</span>
+               </div>
+               <div v-if="allFolders.length" class="context-element-divider" />
+               <div
+                  v-for="folder in allFolders"
+                  :key="folder.uid"
+                  class="context-element"
+                  :class="{ disabled: selectedQuery.folderId === folder.uid }"
+                  @click="moveQueryToFolder(folder.uid)"
+               >
+                  <span class="d-flex">
+                     <BaseIcon
+                        class="text-light mt-1 mr-1"
+                        icon-name="mdiFolder"
+                        :size="18"
+                     /> {{ folder.name }}</span>
+               </div>
+            </div>
+         </div>
+         <div class="context-element-divider" />
+         <div class="context-element" @click="confirmDeleteQuery">
+            <span class="d-flex">
+               <BaseIcon
+                  class="text-light mt-1 mr-1"
+                  icon-name="mdiDeleteForever"
+                  :size="18"
+               /> {{ t('general.delete') }}</span>
+         </div>
+      </BaseContextMenu>
+
+      <ConfirmModal
+         v-if="isRenameModal"
+         size="small"
+         :confirm-text="t('general.save')"
+         :cancel-text="t('general.cancel')"
+         @confirm="confirmRename"
+         @hide="closeRenameModal"
+      >
+         <template #header>
+            <div class="d-flex">
+               <BaseIcon
+                  icon-name="mdiRenameBox"
+                  class="mr-1"
+                  :size="24"
+               />
+               <span>{{ t('general.rename') }}</span>
+            </div>
+         </template>
+         <template #body>
+            <div class="form-group">
+               <input
+                  ref="renameInput"
+                  v-model="renameValue"
+                  type="text"
+                  class="form-input"
+                  @keydown.enter="confirmRename"
+                  @keydown.esc="closeRenameModal"
+               >
+            </div>
+         </template>
+      </ConfirmModal>
+
+      <ConfirmModal
+         v-if="isDeleteModal"
+         size="small"
+         :confirm-text="t('general.delete')"
+         :cancel-text="t('general.cancel')"
+         @confirm="confirmDelete"
+         @hide="closeDeleteModal"
+      >
+         <template #header>
+            <div class="d-flex">
+               <BaseIcon
+                  icon-name="mdiDeleteForever"
+                  class="mr-1"
+                  :size="24"
+               />
+               <span>{{ t('general.delete') }}</span>
+            </div>
+         </template>
+         <template #body>
+            <p>{{ deleteModalMessage }}</p>
+            <div v-if="deleteType === 'folder' && folderHasContents" class="form-group mt-3">
+               <label class="form-checkbox">
+                  <input v-model="deleteContents" type="checkbox">
+                  <i class="form-icon" />
+                  <span>{{ t('database.deleteFolderContents') }}</span>
+               </label>
+            </div>
+         </template>
+      </ConfirmModal>
+   </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import { computed, nextTick, PropType, Ref, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import ConfirmModal from '@/components/BaseConfirmModal.vue';
+import BaseContextMenu from '@/components/BaseContextMenu.vue';
+import BaseIcon from '@/components/BaseIcon.vue';
+import WorkspaceExploreSavedQueriesFolder from '@/components/WorkspaceExploreSavedQueriesFolder.vue';
+import WorkspaceExploreSavedQueriesItem from '@/components/WorkspaceExploreSavedQueriesItem.vue';
+import { useSavedQuerySync } from '@/composables/useSavedQuerySync';
+import { useNotificationsStore } from '@/stores/notifications';
+import { getSavedQueryMarker, QueryFolder, SavedQuery, useSavedQueriesStore } from '@/stores/savedQueries';
+import { useWorkspacesStore } from '@/stores/workspaces';
+
+const { t } = useI18n();
+
+const props = defineProps({
+   connectionUid: {
+      type: String as PropType<string>,
+      required: true
+   }
+});
+
+const savedQueriesStore = useSavedQueriesStore();
+const workspacesStore = useWorkspacesStore();
+const { addNotification } = useNotificationsStore();
+const { renameQueryAndSyncTab, closeTabForQuery } = useSavedQuerySync();
+
+const { getQueriesByConnection, getRootQueries, getRootFolders, getQueryCount } = storeToRefs(savedQueriesStore);
+const { addQuery, addFolder, renameFolder, deleteQuery, deleteFolder, duplicateQuery, moveQueryToFolder: moveQuery, getFolderDepth } = savedQueriesStore;
+const { getWorkspace: getWorkspaceGetter } = storeToRefs(workspacesStore);
+const { newTab, selectTab } = workspacesStore;
+
+const isExpanded = ref(true);
+const accordion: Ref<HTMLDetailsElement> = ref(null);
+const contextEvent: Ref<MouseEvent> = ref(null);
+const isHeaderContext = ref(false);
+const isFolderContext = ref(false);
+const isQueryContext = ref(false);
+const selectedFolder: Ref<QueryFolder | null> = ref(null);
+const selectedQuery: Ref<SavedQuery | null> = ref(null);
+
+const isRenameModal = ref(false);
+const renameValue = ref('');
+const renameType: Ref<'query' | 'folder'> = ref('query');
+const renameInput: Ref<HTMLInputElement> = ref(null);
+
+const isDeleteModal = ref(false);
+const deleteType: Ref<'query' | 'folder'> = ref('query');
+const deleteContents = ref(false);
+
+const connectionQueries = computed(() => getQueriesByConnection.value(props.connectionUid));
+const rootQueries = computed(() => getRootQueries.value(props.connectionUid));
+const rootFolders = computed(() => getRootFolders.value(props.connectionUid));
+const queryCount = computed(() => getQueryCount.value(props.connectionUid));
+const folderCount = computed(() => connectionQueries.value.folders.length);
+const allFolders = computed(() => connectionQueries.value.folders);
+
+const canAddSubfolder = computed(() => {
+   if (!selectedFolder.value) return false;
+   const depth = getFolderDepth(props.connectionUid, selectedFolder.value.uid);
+   return depth < 3;
+});
+
+const folderHasContents = computed(() => {
+   if (!selectedFolder.value) return false;
+   const queriesInFolder = connectionQueries.value.queries.filter(q => q.folderId === selectedFolder.value.uid);
+   const subfoldersInFolder = connectionQueries.value.folders.filter(f => f.parentId === selectedFolder.value.uid);
+   return queriesInFolder.length > 0 || subfoldersInFolder.length > 0;
+});
+
+const deleteModalMessage = computed(() => {
+   if (deleteType.value === 'query' && selectedQuery.value)
+      return `${t('general.deleteConfirm')} "${selectedQuery.value.name}"?`;
+
+   if (deleteType.value === 'folder' && selectedFolder.value)
+      return `${t('general.deleteConfirm')} "${selectedFolder.value.name}"?`;
+
+   return '';
+});
+
+const toggleExpanded = () => {
+   isExpanded.value = !isExpanded.value;
+};
+
+const closeContext = (clearSelection = true) => {
+   isHeaderContext.value = false;
+   isFolderContext.value = false;
+   isQueryContext.value = false;
+   if (clearSelection) {
+      selectedFolder.value = null;
+      selectedQuery.value = null;
+   }
+};
+
+const showHeaderContext = (event: MouseEvent) => {
+   closeContext();
+   contextEvent.value = event;
+   isHeaderContext.value = true;
+};
+
+const showFolderContext = (event: MouseEvent, folder: QueryFolder) => {
+   closeContext();
+   contextEvent.value = event;
+   selectedFolder.value = folder;
+   isFolderContext.value = true;
+};
+
+const showQueryContext = (event: MouseEvent, query: SavedQuery) => {
+   closeContext();
+   contextEvent.value = event;
+   selectedQuery.value = query;
+   isQueryContext.value = true;
+};
+
+const createNewQuery = () => {
+   closeContext();
+   const workspace = getWorkspaceGetter.value(props.connectionUid);
+   const newQueryItem = addQuery({
+      connectionUid: props.connectionUid,
+      name: t('database.newQuery'),
+      sql: '',
+      schema: workspace?.breadcrumbs?.schema,
+      database: workspace?.database
+   });
+   openQuery(newQueryItem);
+};
+
+const createNewFolder = () => {
+   closeContext();
+   addFolder({
+      connectionUid: props.connectionUid,
+      name: t('database.newFolder')
+   });
+};
+
+const createQueryInFolder = () => {
+   if (!selectedFolder.value) return;
+   closeContext();
+   const workspace = getWorkspaceGetter.value(props.connectionUid);
+   const newQueryItem = addQuery({
+      connectionUid: props.connectionUid,
+      name: t('database.newQuery'),
+      sql: '',
+      folderId: selectedFolder.value.uid,
+      schema: workspace?.breadcrumbs?.schema,
+      database: workspace?.database
+   });
+   openQuery(newQueryItem);
+};
+
+const createSubfolder = () => {
+   if (!selectedFolder.value) return;
+   closeContext();
+   addFolder({
+      connectionUid: props.connectionUid,
+      name: t('database.newFolder'),
+      parentId: selectedFolder.value.uid
+   });
+};
+
+const openQuery = (query: SavedQuery) => {
+   if (!query || !query.uid) {
+      addNotification({ status: 'error', message: 'Invalid query object' });
+      return;
+   }
+
+   const workspace = getWorkspaceGetter.value(props.connectionUid);
+   if (!workspace || workspace.connectionStatus !== 'connected') return;
+
+   const savedQueryMarker = getSavedQueryMarker(query.uid);
+   const existingTab = workspace.tabs.find(
+      tab => tab.type === 'query' && tab.elementType === savedQueryMarker
+   );
+
+   if (existingTab) {
+      selectTab({ uid: props.connectionUid, tab: existingTab.uid });
+      return;
+   }
+
+   const sqlContent = query.sql || '';
+
+   newTab({
+      uid: props.connectionUid,
+      type: 'query',
+      content: sqlContent,
+      elementName: query.name,
+      elementType: savedQueryMarker,
+      autorun: false,
+      schema: query.schema || workspace.breadcrumbs.schema
+   });
+};
+
+const runQuery = (query: SavedQuery) => {
+   const workspace = getWorkspaceGetter.value(props.connectionUid);
+   if (!workspace || workspace.connectionStatus !== 'connected') return;
+
+   const savedQueryMarker = getSavedQueryMarker(query.uid);
+   const existingTab = workspace.tabs.find(
+      tab => tab.type === 'query' && tab.elementType === savedQueryMarker
+   );
+
+   if (existingTab) {
+      selectTab({ uid: props.connectionUid, tab: existingTab.uid });
+      return;
+   }
+
+   newTab({
+      uid: props.connectionUid,
+      type: 'query',
+      content: query.sql || '',
+      elementName: query.name,
+      elementType: savedQueryMarker,
+      autorun: true,
+      schema: query.schema || workspace.breadcrumbs.schema
+   });
+};
+
+const openSelectedQuery = () => {
+   if (selectedQuery.value)
+      openQuery(selectedQuery.value);
+
+   closeContext();
+};
+
+const runSelectedQuery = () => {
+   if (selectedQuery.value)
+      runQuery(selectedQuery.value);
+
+   closeContext();
+};
+
+const startRenameQuery = () => {
+   if (!selectedQuery.value) return;
+   renameType.value = 'query';
+   renameValue.value = selectedQuery.value.name;
+   closeContext(false);
+   isRenameModal.value = true;
+   nextTick(() => {
+      renameInput.value?.focus();
+      renameInput.value?.select();
+   });
+};
+
+const startRenameFolder = () => {
+   if (!selectedFolder.value) return;
+   renameType.value = 'folder';
+   renameValue.value = selectedFolder.value.name;
+   closeContext(false);
+   isRenameModal.value = true;
+   nextTick(() => {
+      renameInput.value?.focus();
+      renameInput.value?.select();
+   });
+};
+
+const confirmRename = () => {
+   if (!renameValue.value.trim()) return;
+
+   if (renameType.value === 'query' && selectedQuery.value) {
+      renameQueryAndSyncTab(
+         props.connectionUid,
+         selectedQuery.value.uid,
+         renameValue.value.trim()
+      );
+   }
+   else if (renameType.value === 'folder' && selectedFolder.value) {
+      renameFolder({
+         connectionUid: props.connectionUid,
+         folderUid: selectedFolder.value.uid,
+         name: renameValue.value.trim()
+      });
+   }
+
+   closeRenameModal();
+};
+
+const closeRenameModal = () => {
+   isRenameModal.value = false;
+   renameValue.value = '';
+   selectedQuery.value = null;
+   selectedFolder.value = null;
+};
+
+const duplicateSelectedQuery = () => {
+   if (selectedQuery.value) {
+      duplicateQuery({
+         connectionUid: props.connectionUid,
+         queryUid: selectedQuery.value.uid
+      });
+   }
+   closeContext();
+};
+
+const moveQueryToFolder = (folderId: string | null) => {
+   if (selectedQuery.value && selectedQuery.value.folderId !== folderId) {
+      moveQuery({
+         connectionUid: props.connectionUid,
+         queryUid: selectedQuery.value.uid,
+         folderId
+      });
+   }
+   closeContext();
+};
+
+const confirmDeleteQuery = () => {
+   deleteType.value = 'query';
+   deleteContents.value = false;
+   closeContext(false);
+   isDeleteModal.value = true;
+};
+
+const confirmDeleteFolder = () => {
+   deleteType.value = 'folder';
+   deleteContents.value = false;
+   closeContext(false);
+   isDeleteModal.value = true;
+};
+
+const confirmDelete = () => {
+   if (deleteType.value === 'query' && selectedQuery.value) {
+      closeTabForQuery(props.connectionUid, selectedQuery.value.uid);
+      deleteQuery({
+         connectionUid: props.connectionUid,
+         queryUid: selectedQuery.value.uid
+      });
+   }
+   else if (deleteType.value === 'folder' && selectedFolder.value) {
+      deleteFolder({
+         connectionUid: props.connectionUid,
+         folderUid: selectedFolder.value.uid,
+         deleteContents: deleteContents.value
+      });
+   }
+
+   closeDeleteModal();
+};
+
+const closeDeleteModal = () => {
+   isDeleteModal.value = false;
+   selectedQuery.value = null;
+   selectedFolder.value = null;
+   deleteContents.value = false;
+};
+
+defineExpose({
+   openQuery,
+   runQuery
+});
+</script>
+
+<style lang="scss" scoped>
+.workspace-saved-queries {
+
+   .saved-queries-header {
+      display: flex;
+      align-items: center;
+      padding: 0.25rem 0.4rem;
+      cursor: pointer;
+      user-select: none;
+
+      &:hover {
+         background: var(--bg-color-light-dark);
+      }
+
+      .icon {
+         transition: transform 0.2s;
+         min-width: 18px;
+      }
+
+      .saved-queries-title {
+         font-weight: 600;
+         font-size: 0.7rem;
+         text-transform: uppercase;
+      }
+
+      .saved-queries-count {
+         font-size: 0.65rem;
+         opacity: 0.7;
+         margin-left: 0.25rem;
+      }
+
+      .saved-queries-tools {
+         margin-left: auto;
+         display: flex;
+         align-items: center;
+         opacity: 0;
+         transition: opacity 0.2s;
+
+         svg {
+            opacity: 0.6;
+            transition: opacity 0.2s;
+
+            &:hover {
+               opacity: 1;
+            }
+         }
+      }
+
+      &:hover .saved-queries-tools {
+         opacity: 1;
+      }
+   }
+
+   .accordion[open] > .saved-queries-header .icon {
+      transform: rotate(90deg);
+   }
+
+   .empty-state {
+      padding: 0.5rem 1rem;
+      opacity: 0.6;
+      font-style: italic;
+   }
+
+   .saved-queries-list {
+      padding-left: 0.25rem;
+   }
+}
+
+.context-element-submenu {
+   .submenu-arrow {
+      margin-left: auto;
+   }
+}
+</style>

--- a/src/renderer/components/WorkspaceExploreSavedQueriesFolder.vue
+++ b/src/renderer/components/WorkspaceExploreSavedQueriesFolder.vue
@@ -1,0 +1,214 @@
+<template>
+   <li class="menu-item saved-query-folder" :style="{ paddingLeft: `${depth * 12}px` }">
+      <div class="accordion folder-accordion" :class="{ 'open': folder.isExpanded }">
+         <div
+            class="folder-header"
+            @click="toggleFolder"
+            @dblclick.prevent="startRename"
+            @contextmenu.prevent="showContext"
+         >
+            <BaseIcon
+               class="folder-caret"
+               icon-name="mdiChevronRight"
+               :size="14"
+            />
+            <BaseIcon
+               v-if="folder.isExpanded"
+               class="folder-icon mr-1"
+               icon-name="mdiFolderOpen"
+               :size="16"
+            />
+            <BaseIcon
+               v-else
+               class="folder-icon mr-1"
+               icon-name="mdiFolder"
+               :size="16"
+            />
+            <span v-if="!isRenaming" class="folder-name">{{ folder.name }}</span>
+            <input
+               v-else
+               ref="renameInput"
+               v-model="renameValue"
+               type="text"
+               class="form-input input-sm folder-rename-input"
+               @blur="confirmRename"
+               @keydown.enter="confirmRename"
+               @keydown.esc="cancelRename"
+               @keydown.stop
+               @keypress.stop
+               @click.stop
+               @dblclick.stop
+            >
+         </div>
+         <div v-show="folder.isExpanded" class="accordion-body folder-contents">
+            <WorkspaceExploreSavedQueriesFolder
+               v-for="subfolder in subfolders"
+               :key="subfolder.uid"
+               :folder="subfolder"
+               :connection-uid="connectionUid"
+               :depth="depth + 1"
+               @open-query="handleOpenQuery"
+               @run-query="handleRunQuery"
+               @show-folder-context="handleShowFolderContext"
+               @show-query-context="handleShowQueryContext"
+            />
+            <WorkspaceExploreSavedQueriesItem
+               v-for="query in queriesInFolder"
+               :key="query.uid"
+               :query="query"
+               :connection-uid="connectionUid"
+               :depth="depth + 1"
+               @open-query="handleOpenQuery"
+               @run-query="handleRunQuery"
+               @show-context="handleShowQueryContext"
+            />
+         </div>
+      </div>
+   </li>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import { computed, nextTick, PropType, Ref, ref } from 'vue';
+
+import BaseIcon from '@/components/BaseIcon.vue';
+import WorkspaceExploreSavedQueriesItem from '@/components/WorkspaceExploreSavedQueriesItem.vue';
+import { QueryFolder, SavedQuery, useSavedQueriesStore } from '@/stores/savedQueries';
+
+const props = defineProps({
+   folder: {
+      type: Object as PropType<QueryFolder>,
+      required: true
+   },
+   connectionUid: {
+      type: String as PropType<string>,
+      required: true
+   },
+   depth: {
+      type: Number as PropType<number>,
+      default: 0
+   }
+});
+
+const emit = defineEmits(['open-query', 'run-query', 'show-folder-context', 'show-query-context']);
+
+const savedQueriesStore = useSavedQueriesStore();
+const { getQueriesInFolder, getSubfolders } = storeToRefs(savedQueriesStore);
+const { toggleFolderExpanded, renameFolder } = savedQueriesStore;
+
+const isRenaming = ref(false);
+const renameValue = ref('');
+const renameInput: Ref<HTMLInputElement> = ref(null);
+
+const subfolders = computed(() => getSubfolders.value(props.connectionUid, props.folder.uid));
+const queriesInFolder = computed(() => getQueriesInFolder.value(props.connectionUid, props.folder.uid));
+
+const toggleFolder = () => {
+   toggleFolderExpanded({
+      connectionUid: props.connectionUid,
+      folderUid: props.folder.uid
+   });
+};
+
+const showContext = (event: MouseEvent) => {
+   emit('show-folder-context', event, props.folder);
+};
+
+const handleOpenQuery = (query: SavedQuery) => {
+   emit('open-query', query);
+};
+
+const handleRunQuery = (query: SavedQuery) => {
+   emit('run-query', query);
+};
+
+const handleShowFolderContext = (event: MouseEvent, folder: QueryFolder) => {
+   emit('show-folder-context', event, folder);
+};
+
+const handleShowQueryContext = (event: MouseEvent, query: SavedQuery) => {
+   emit('show-query-context', event, query);
+};
+
+const startRename = () => {
+   renameValue.value = props.folder.name;
+   isRenaming.value = true;
+   nextTick(() => {
+      renameInput.value?.focus();
+      renameInput.value?.select();
+   });
+};
+
+const confirmRename = () => {
+   if (renameValue.value.trim() && renameValue.value !== props.folder.name) {
+      renameFolder({
+         connectionUid: props.connectionUid,
+         folderUid: props.folder.uid,
+         name: renameValue.value.trim()
+      });
+   }
+   isRenaming.value = false;
+};
+
+const cancelRename = () => {
+   isRenaming.value = false;
+   renameValue.value = props.folder.name;
+};
+</script>
+
+<style lang="scss" scoped>
+.saved-query-folder {
+   list-style: none;
+
+   .folder-accordion {
+      width: 100%;
+   }
+
+   .folder-header {
+      display: flex;
+      align-items: center;
+      padding: 0.2rem 0.25rem;
+      cursor: pointer;
+      border-radius: $border-radius;
+      user-select: none;
+
+      &:hover {
+         background: var(--bg-color-light-dark);
+      }
+
+      .folder-caret {
+         transition: transform 0.2s;
+         min-width: 14px;
+         opacity: 0.6;
+      }
+
+      .folder-icon {
+         color: var(--primary-color);
+         min-width: 16px;
+      }
+
+      .folder-name {
+         font-size: 0.7rem;
+         white-space: nowrap;
+         overflow: hidden;
+         text-overflow: ellipsis;
+      }
+
+      .folder-rename-input {
+         font-size: 0.7rem;
+         height: 1.2rem;
+         padding: 0 0.25rem;
+         flex: 1;
+         min-width: 0;
+      }
+   }
+
+   .folder-accordion.open > .folder-header .folder-caret {
+      transform: rotate(90deg);
+   }
+
+   .folder-contents {
+      padding-left: 0.5rem;
+   }
+}
+</style>

--- a/src/renderer/components/WorkspaceExploreSavedQueriesItem.vue
+++ b/src/renderer/components/WorkspaceExploreSavedQueriesItem.vue
@@ -1,0 +1,195 @@
+<template>
+   <li
+      class="menu-item saved-query-item"
+      :style="{ paddingLeft: `${(depth || 0) * 12}px` }"
+      @click="handleClick"
+      @dblclick="startRename"
+      @contextmenu.prevent="showContext"
+   >
+      <div class="query-content">
+         <BaseIcon
+            class="query-icon mr-1"
+            icon-name="mdiCodeBrackets"
+            :size="16"
+         />
+         <span
+            v-if="!isRenaming"
+            v-tooltip="{
+               strategy: 'fixed',
+               placement: 'right',
+               content: queryPreview,
+               delay: { show: 500, hide: 0 }
+            }"
+            class="query-name"
+         >
+            {{ query.name }}
+         </span>
+         <input
+            v-else
+            ref="renameInput"
+            v-model="renameValue"
+            type="text"
+            class="form-input input-sm query-rename-input"
+            @blur="confirmRename"
+            @keydown.enter="confirmRename"
+            @keydown.esc="cancelRename"
+            @keydown.stop
+            @keypress.stop
+            @click.stop
+            @dblclick.stop
+         >
+         <button
+            v-tooltip="{
+               strategy: 'fixed',
+               content: t('database.runQuery')
+            }"
+            class="btn btn-link btn-sm query-run-btn"
+            @click.stop="handleRun"
+         >
+            <BaseIcon icon-name="mdiPlay" :size="14" />
+         </button>
+      </div>
+   </li>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, PropType, Ref, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import BaseIcon from '@/components/BaseIcon.vue';
+import { useSavedQuerySync } from '@/composables/useSavedQuerySync';
+import { SavedQuery } from '@/stores/savedQueries';
+
+const { t } = useI18n();
+
+const props = defineProps({
+   query: {
+      type: Object as PropType<SavedQuery>,
+      required: true
+   },
+   connectionUid: {
+      type: String as PropType<string>,
+      required: true
+   },
+   depth: {
+      type: Number as PropType<number>,
+      default: 0
+   }
+});
+
+const emit = defineEmits(['open-query', 'run-query', 'show-context']);
+
+const { renameQueryAndSyncTab } = useSavedQuerySync();
+
+const isRenaming = ref(false);
+const renameValue = ref('');
+const renameInput: Ref<HTMLInputElement> = ref(null);
+
+const queryPreview = computed(() => {
+   const sql = props.query.sql || '';
+   if (sql.length > 100)
+      return sql.substring(0, 100) + '...';
+
+   return sql || t('database.emptyQuery');
+});
+
+const handleClick = () => {
+   if (!isRenaming.value)
+      emit('open-query', props.query);
+};
+
+const handleRun = () => {
+   emit('run-query', props.query);
+};
+
+const showContext = (event: MouseEvent) => {
+   emit('show-context', event, props.query);
+};
+
+const startRename = () => {
+   renameValue.value = props.query.name;
+   isRenaming.value = true;
+   nextTick(() => {
+      renameInput.value?.focus();
+      renameInput.value?.select();
+   });
+};
+
+const confirmRename = () => {
+   if (renameValue.value.trim() && renameValue.value !== props.query.name) {
+      renameQueryAndSyncTab(
+         props.connectionUid,
+         props.query.uid,
+         renameValue.value.trim()
+      );
+   }
+   isRenaming.value = false;
+};
+
+const cancelRename = () => {
+   isRenaming.value = false;
+   renameValue.value = props.query.name;
+};
+</script>
+
+<style lang="scss" scoped>
+.saved-query-item {
+   list-style: none;
+   cursor: pointer;
+
+   .query-content {
+      display: flex;
+      align-items: center;
+      padding: 0.2rem 0.25rem;
+      border-radius: $border-radius;
+
+      &:hover {
+         background: var(--bg-color-light-dark);
+
+         .query-run-btn {
+            opacity: 1;
+         }
+      }
+   }
+
+   .query-icon {
+      color: var(--primary-color);
+      min-width: 16px;
+      opacity: 0.8;
+   }
+
+   .query-name {
+      font-size: 0.7rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex: 1;
+      min-width: 0;
+   }
+
+   .query-rename-input {
+      font-size: 0.7rem;
+      height: 1.2rem;
+      padding: 0 0.25rem;
+      flex: 1;
+      min-width: 0;
+   }
+
+   .query-run-btn {
+      opacity: 0;
+      transition: opacity 0.2s;
+      padding: 0 0.15rem;
+      height: auto;
+      min-height: 0;
+      margin-left: auto;
+
+      &:hover {
+         color: var(--primary-color);
+      }
+
+      svg {
+         display: block;
+      }
+   }
+}
+</style>

--- a/src/renderer/components/WorkspaceTabQuery.vue
+++ b/src/renderer/components/WorkspaceTabQuery.vue
@@ -122,24 +122,14 @@
                      <BaseIcon icon-name="mdiFolderOpenOutline" :size="24" />
                   </button>
                </div>
-               <div class="btn-group">
-                  <button
-                     class="btn btn-dark btn-sm mr-0"
-                     :disabled="isQuering || (isQuerySaved || query.length < 5)"
-                     :title="t('application.saveAsNote')"
-                     @click="saveQuery()"
-                  >
-                     <BaseIcon icon-name="mdiHeartPlusOutline" :size="24" />
-                  </button>
-                  <button
-                     class="btn btn-dark btn-sm"
-                     :disabled="isQuering"
-                     :title="t('database.savedQueries')"
-                     @click="openSavedModal()"
-                  >
-                     <BaseIcon icon-name="mdiNotebookHeartOutline" :size="24" />
-                  </button>
-               </div>
+               <button
+                  class="btn btn-dark btn-sm"
+                  :disabled="isQuering || (isQuerySaved || query.length < 5)"
+                  :title="t('database.savedQueries')"
+                  @click="saveQuery()"
+               >
+                  <BaseIcon icon-name="mdiBookmarkPlusOutline" :size="24" />
+               </button>
                <button
                   class="btn btn-dark btn-sm"
                   :disabled="isQuering"
@@ -197,6 +187,30 @@
                </div>
             </div>
             <div class="workspace-query-info">
+               <div
+                  v-if="saveStatus === 'saving'"
+                  class="d-flex save-status saving"
+                  :title="t('database.autoSaving')"
+               >
+                  <BaseIcon
+                     class="mr-1 mt-1 rotating"
+                     icon-name="mdiLoading"
+                     :size="16"
+                  />
+                  <span>{{ t('database.autoSaving') }}</span>
+               </div>
+               <div
+                  v-else-if="saveStatus === 'saved'"
+                  class="d-flex save-status saved"
+                  :title="t('database.autoSaved')"
+               >
+                  <BaseIcon
+                     class="mr-1 mt-1"
+                     icon-name="mdiCheck"
+                     :size="16"
+                  />
+                  <span>{{ t('database.autoSaved') }}</span>
+               </div>
                <div
                   v-if="results.length"
                   class="d-flex"
@@ -277,7 +291,6 @@
 import { getCurrentWindow, Menu } from '@electron/remote';
 import { Ace } from 'ace-builds';
 import { ConnectionParams } from 'common/interfaces/antares';
-import { uidGen } from 'common/libs/uidGen';
 import { ipcRenderer } from 'electron';
 import { storeToRefs } from 'pinia';
 import { format } from 'sql-formatter';
@@ -294,11 +307,10 @@ import WorkspaceTabQueryTable from '@/components/WorkspaceTabQueryTable.vue';
 import { useResultTables } from '@/composables/useResultTables';
 import Application from '@/ipc-api/Application';
 import Schema from '@/ipc-api/Schema';
-import { useApplicationStore } from '@/stores/application';
 import { useConsoleStore } from '@/stores/console';
 import { useHistoryStore } from '@/stores/history';
 import { useNotificationsStore } from '@/stores/notifications';
-import { useScratchpadStore } from '@/stores/scratchpad';
+import { extractQueryUidFromMarker, isSavedQueryMarker, useSavedQueriesStore } from '@/stores/savedQueries';
 import { useSettingsStore } from '@/stores/settings';
 import { useWorkspacesStore } from '@/stores/workspaces';
 
@@ -323,8 +335,8 @@ const {
 const { saveHistory } = useHistoryStore();
 const { addNotification } = useNotificationsStore();
 const workspacesStore = useWorkspacesStore();
-const { showScratchpad } = useApplicationStore();
-const { addNote } = useScratchpadStore();
+const savedQueriesStore = useSavedQueriesStore();
+const { addQuery, updateQuery } = savedQueriesStore;
 
 const { consoleHeight } = storeToRefs(useConsoleStore());
 const { executeSelected } = storeToRefs(useSettingsStore());
@@ -356,7 +368,10 @@ const affectedCount = ref(null);
 const editorHeight = ref(200);
 const isQuerySaved = ref(false);
 const isHistoryOpen = ref(false);
-const debounceTimeout = ref(null);
+const queryDebounceTimeout = ref(null);
+const nameDebounceTimeout = ref(null);
+const isSaving = ref(false);
+const saveStatus = ref<'idle' | 'saving' | 'saved'>('idle');
 
 const workspace = computed(() => getWorkspace(props.connection.uid));
 const breadcrumbsSchema = computed(() => workspace.value.breadcrumbs.schema || null);
@@ -373,45 +388,113 @@ const isChanged = computed(() => {
 });
 
 watch(query, (val) => {
-   clearTimeout(debounceTimeout.value);
+   clearTimeout(queryDebounceTimeout.value);
 
-   debounceTimeout.value = setTimeout(() => {
+   const elementType = props.tab.elementType;
+   const connectionUid = props.connection.uid;
+   const tabUid = props.tab.uid;
+   const currentSchema = selectedSchema.value;
+   const currentElementName = queryName.value;
+   const currentFilePath = filePath.value;
+   const isTabSavedQuery = isSavedQueryMarker(elementType);
+   const queryUid = extractQueryUidFromMarker(elementType);
+
+   if (isTabSavedQuery) {
+      saveStatus.value = 'saving';
+      isSaving.value = true;
+   }
+
+   queryDebounceTimeout.value = setTimeout(() => {
       updateTabContent({
-         elementName: queryName.value,
-         filePath: filePath.value,
-         uid: props.connection.uid,
-         tab: props.tab.uid,
+         elementName: currentElementName,
+         filePath: currentFilePath,
+         uid: connectionUid,
+         tab: tabUid,
          type: 'query',
-         schema: selectedSchema.value,
-         content: val
-
+         schema: currentSchema,
+         content: val,
+         elementType
       });
 
-      isQuerySaved.value = false;
-   }, 200);
+      if (isTabSavedQuery && queryUid) {
+         updateQuery({
+            connectionUid,
+            queryUid,
+            sql: val,
+            schema: currentSchema
+         });
+         isQuerySaved.value = true;
+         saveStatus.value = 'saved';
+         isSaving.value = false;
+
+         setTimeout(() => {
+            if (saveStatus.value === 'saved')
+               saveStatus.value = 'idle';
+         }, 2000);
+      }
+      else {
+         isQuerySaved.value = false;
+         saveStatus.value = 'idle';
+         isSaving.value = false;
+      }
+   }, 500);
 });
 
 watch(queryName, (val) => {
-   clearTimeout(debounceTimeout.value);
+   clearTimeout(nameDebounceTimeout.value);
 
-   debounceTimeout.value = setTimeout(() => {
+   const elementType = props.tab.elementType;
+   const connectionUid = props.connection.uid;
+   const tabUid = props.tab.uid;
+   const currentSchema = selectedSchema.value;
+   const currentFilePath = filePath.value;
+   const currentQuery = query.value;
+   const isTabSavedQuery = isSavedQueryMarker(elementType);
+   const queryUid = extractQueryUidFromMarker(elementType);
+
+   if (isTabSavedQuery) {
+      saveStatus.value = 'saving';
+      isSaving.value = true;
+   }
+
+   nameDebounceTimeout.value = setTimeout(() => {
       updateTabContent({
          elementName: val,
-         filePath: filePath.value,
-         uid: props.connection.uid,
-         tab: props.tab.uid,
+         filePath: currentFilePath,
+         uid: connectionUid,
+         tab: tabUid,
          type: 'query',
-         schema: selectedSchema.value,
-         content: query.value
+         schema: currentSchema,
+         content: currentQuery,
+         elementType
       });
 
-      isQuerySaved.value = false;
-   }, 200);
+      if (isTabSavedQuery && queryUid) {
+         updateQuery({
+            connectionUid,
+            queryUid,
+            name: val
+         });
+         isQuerySaved.value = true;
+         saveStatus.value = 'saved';
+         isSaving.value = false;
+
+         setTimeout(() => {
+            if (saveStatus.value === 'saved')
+               saveStatus.value = 'idle';
+         }, 2000);
+      }
+      else {
+         isQuerySaved.value = false;
+         saveStatus.value = 'idle';
+         isSaving.value = false;
+      }
+   }, 500);
 });
 
 watch(() => props.isSelected, (val) => {
    if (val) {
-      changeBreadcrumbs({ schema: selectedSchema.value, query: `Query #${props.tab.index}` });
+      changeBreadcrumbs({ schema: selectedSchema.value, query: 'New Query' });
       setTimeout(() => {
          if (queryEditor.value)
             queryEditor.value.editor.focus();
@@ -420,7 +503,7 @@ watch(() => props.isSelected, (val) => {
 });
 
 watch(selectedSchema, () => {
-   changeBreadcrumbs({ schema: selectedSchema.value, query: `Query #${props.tab.index}` });
+   changeBreadcrumbs({ schema: selectedSchema.value, query: 'New Query' });
 });
 
 watch(databaseSchemas, () => {
@@ -434,6 +517,11 @@ watch(() => props.tab.content, () => {
 
    if (editorValue !== query.value)// If change not rendered in editor
       queryEditor.value.editor.session.setValue(query.value);
+});
+
+watch(() => props.tab.elementName, (newName) => {
+   if (newName !== queryName.value)
+      queryName.value = newName as string;
 });
 
 watch(isChanged, (val) => {
@@ -588,20 +676,15 @@ const openHistoryModal = () => {
 };
 
 const saveQuery = () => {
-   addNote({
-      uid: uidGen('N'),
-      cUid: workspace.value.uid,
-      type: 'query',
-      date: new Date(),
-      note: query.value,
-      isArchived: false,
-      title: queryName.value
+   addQuery({
+      connectionUid: workspace.value.uid,
+      name: queryName.value || t('database.newQuery'),
+      sql: query.value,
+      schema: breadcrumbsSchema.value,
+      database: workspace.value.database
    });
    isQuerySaved.value = true;
-};
-
-const openSavedModal = () => {
-   showScratchpad('query');
+   addNotification({ status: 'success', message: t('general.actionSuccessful', { action: t('general.save') }) });
 };
 
 const selectQuery = (sql: string) => {
@@ -662,7 +745,30 @@ const rollbackTab = async () => {
 defineExpose({ resizeResults });
 
 query.value = props.tab.content as string;
-queryName.value = props.tab.elementName as string;
+if (isSavedQueryMarker(props.tab.elementType)) {
+   const queryUid = extractQueryUidFromMarker(props.tab.elementType);
+
+   const savedQuery = queryUid ? savedQueriesStore.getQueryById(props.connection.uid, queryUid) : null;
+   if (savedQuery) {
+      query.value = savedQuery.sql;
+      queryName.value = savedQuery.name;
+      updateTabContent({
+         elementName: savedQuery.name,
+         filePath: filePath.value,
+         uid: props.connection.uid,
+         tab: props.tab.uid,
+         type: 'query',
+         schema: selectedSchema.value,
+         content: query.value,
+         elementType: props.tab.elementType
+      });
+   }
+   else
+      queryName.value = props.tab.elementName as string;
+}
+else
+   queryName.value = props.tab.elementName as string;
+
 filePath.value = props.tab.filePath as string;
 selectedSchema.value = props.tab.schema || breadcrumbsSchema.value;
 
@@ -926,6 +1032,23 @@ onBeforeUnmount(() => {
         > div + div {
           padding-left: 0.6rem;
         }
+
+        .save-status {
+          font-size: 0.75rem;
+          align-items: center;
+
+          &.saving {
+            color: var(--primary-color);
+          }
+
+          &.saved {
+            color: var(--success-color, #28a745);
+          }
+
+          .rotating {
+            animation: rotate 1s linear infinite;
+          }
+        }
       }
     }
   }
@@ -934,4 +1057,13 @@ onBeforeUnmount(() => {
     min-height: 200px;
   }
 }
-</style>filePathsfilePathsfilePaths
+
+@keyframes rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/renderer/composables/useSavedQuerySync.ts
+++ b/src/renderer/composables/useSavedQuerySync.ts
@@ -1,0 +1,52 @@
+import {
+   getSavedQueryMarker,
+   useSavedQueriesStore
+} from '@/stores/savedQueries';
+import { useWorkspacesStore } from '@/stores/workspaces';
+
+export function useSavedQuerySync () {
+   const savedQueriesStore = useSavedQueriesStore();
+   const workspacesStore = useWorkspacesStore();
+
+   const renameQueryAndSyncTab = (connectionUid: string, queryUid: string, newName: string): void => {
+      savedQueriesStore.renameQuery({ connectionUid, queryUid, name: newName });
+
+      const workspace = workspacesStore.getWorkspace(connectionUid);
+      if (!workspace) return;
+
+      const savedQueryMarker = getSavedQueryMarker(queryUid);
+      const openTab = workspace.tabs.find(
+         tab => tab.type === 'query' && tab.elementType === savedQueryMarker
+      );
+
+      if (openTab) {
+         workspacesStore.updateTabContent({
+            uid: connectionUid,
+            tab: openTab.uid,
+            type: openTab.type,
+            schema: openTab.schema,
+            content: openTab.content,
+            elementName: newName,
+            elementType: openTab.elementType,
+            filePath: openTab.filePath
+         });
+      }
+   };
+
+   const closeTabForQuery = (connectionUid: string, queryUid: string): void => {
+      const workspace = workspacesStore.getWorkspace(connectionUid);
+      if (!workspace) return;
+
+      const savedQueryMarker = getSavedQueryMarker(queryUid);
+      const openTab = workspace.tabs.find(
+         tab => tab.type === 'query' && tab.elementType === savedQueryMarker
+      );
+
+      if (openTab) workspacesStore.removeTab({ uid: connectionUid, tab: openTab.uid });
+   };
+
+   return {
+      renameQueryAndSyncTab,
+      closeTabForQuery
+   };
+}

--- a/src/renderer/i18n/en-US.ts
+++ b/src/renderer/i18n/en-US.ts
@@ -80,7 +80,9 @@ export const enUS = {
       title: 'Title',
       archive: 'Archive', // verb
       undo: 'Undo',
-      moveTo: 'Move to'
+      moveTo: 'Move to',
+      rename: 'Rename',
+      root: 'Root'
    },
    connection: { // Database connection
       connection: 'Connection',
@@ -118,7 +120,8 @@ export const enUS = {
       allConnections: 'All connections',
       searchForConnections: 'Search for connections',
       keepAliveInterval: 'Keep alive interval',
-      singleConnection: 'Single connection'
+      singleConnection: 'Single connection',
+      databases: 'Databses'
    },
    database: { // Database related terms
       schema: 'Schema',
@@ -291,7 +294,18 @@ export const enUS = {
       switchDatabase: 'Switch the database',
       searchForElements: 'Search for elements',
       searchForSchemas: 'Search for schemas',
-      savedQueries: 'Saved queries'
+      savedQueries: 'Saved queries',
+      newQuery: 'New query',
+      newFolder: 'New folder',
+      newSubfolder: 'New subfolder',
+      createNewQuery: 'Create new query',
+      noSavedQueries: 'No saved queries',
+      openInNewTab: 'Open in new tab',
+      deleteFolderContents: 'Delete folder contents',
+      emptyQuery: 'Empty query',
+      rename: 'Rename',
+      autoSaving: 'Saving...',
+      autoSaved: 'Saved'
    },
    application: { // Application related terms
       settings: 'Settings',

--- a/src/renderer/stores/savedQueries.ts
+++ b/src/renderer/stores/savedQueries.ts
@@ -1,0 +1,244 @@
+import { uidGen } from 'common/libs/uidGen';
+import * as Store from 'electron-store';
+import { defineStore } from 'pinia';
+
+const persistentStore = new Store({ name: 'saved-queries' });
+
+export const SAVED_QUERY_MARKER_PREFIX = 'saved-query:';
+export const getSavedQueryMarker = (queryUid: string): string => `${SAVED_QUERY_MARKER_PREFIX}${queryUid}`;
+export const isSavedQueryMarker = (elementType?: string): boolean =>
+   elementType?.startsWith(SAVED_QUERY_MARKER_PREFIX) ?? false;
+export const extractQueryUidFromMarker = (elementType: string): string | null =>
+   isSavedQueryMarker(elementType) ? elementType.replace(SAVED_QUERY_MARKER_PREFIX, '') : null;
+
+export interface SavedQuery {
+   uid: string;
+   name: string;
+   sql: string;
+   folderId: string | null;
+   connectionUid: string;
+   schema?: string;
+   database?: string;
+   createdAt: string;
+   updatedAt: string;
+}
+
+export interface QueryFolder {
+   uid: string;
+   name: string;
+   connectionUid: string;
+   parentId: string | null;
+   isExpanded?: boolean;
+   createdAt: string;
+}
+
+export interface ConnectionQueries {
+   queries: SavedQuery[];
+   folders: QueryFolder[];
+}
+
+export const useSavedQueriesStore = defineStore('savedQueries', {
+   state: () => ({
+      queriesByConnection: persistentStore.get('queriesByConnection', {}) as Record<string, ConnectionQueries>
+   }),
+   getters: {
+      getQueriesByConnection: (state) => (connectionUid: string): ConnectionQueries => {
+         return state.queriesByConnection[connectionUid] || { queries: [], folders: [] };
+      },
+      getQueryById: (state) => (connectionUid: string, queryUid: string): SavedQuery | undefined => {
+         const connectionData = state.queriesByConnection[connectionUid];
+         if (!connectionData) return undefined;
+         return connectionData.queries.find(q => q.uid === queryUid);
+      },
+      getFolderById: (state) => (connectionUid: string, folderUid: string): QueryFolder | undefined => {
+         const connectionData = state.queriesByConnection[connectionUid];
+         if (!connectionData) return undefined;
+         return connectionData.folders.find(f => f.uid === folderUid);
+      },
+      getRootQueries: (state) => (connectionUid: string): SavedQuery[] => {
+         const connectionData = state.queriesByConnection[connectionUid];
+         if (!connectionData) return [];
+         return connectionData.queries.filter(q => q.folderId === null);
+      },
+      getRootFolders: (state) => (connectionUid: string): QueryFolder[] => {
+         const connectionData = state.queriesByConnection[connectionUid];
+         if (!connectionData) return [];
+         return connectionData.folders.filter(f => f.parentId === null);
+      },
+      getQueriesInFolder: (state) => (connectionUid: string, folderId: string): SavedQuery[] => {
+         const connectionData = state.queriesByConnection[connectionUid];
+         if (!connectionData) return [];
+         return connectionData.queries.filter(q => q.folderId === folderId);
+      },
+      getSubfolders: (state) => (connectionUid: string, parentId: string): QueryFolder[] => {
+         const connectionData = state.queriesByConnection[connectionUid];
+         if (!connectionData) return [];
+         return connectionData.folders.filter(f => f.parentId === parentId);
+      },
+      getQueryCount: (state) => (connectionUid: string): number => {
+         const connectionData = state.queriesByConnection[connectionUid];
+         if (!connectionData) return 0;
+         return connectionData.queries.length;
+      }
+   },
+   actions: {
+      _ensureConnectionData (connectionUid: string): void {
+         if (!this.queriesByConnection[connectionUid]) this.queriesByConnection[connectionUid] = { queries: [], folders: [] };
+      },
+      _persist (): void {
+         persistentStore.set('queriesByConnection', this.queriesByConnection);
+      },
+      addQuery (args: { connectionUid: string; name: string; sql: string; folderId?: string; schema?: string; database?: string }): SavedQuery {
+         this._ensureConnectionData(args.connectionUid);
+
+         const now = new Date().toISOString();
+         const newQuery: SavedQuery = {
+            uid: uidGen('SQ'),
+            name: args.name,
+            sql: args.sql,
+            folderId: args.folderId ?? null,
+            connectionUid: args.connectionUid,
+            schema: args.schema,
+            database: args.database,
+            createdAt: now,
+            updatedAt: now
+         };
+
+         this.queriesByConnection[args.connectionUid].queries.push(newQuery);
+         this._persist();
+         return newQuery;
+      },
+      updateQuery (args: { connectionUid: string; queryUid: string; name?: string; sql?: string; folderId?: string; schema?: string; database?: string }): void {
+         const connectionData = this.queriesByConnection[args.connectionUid];
+         if (!connectionData) return;
+
+         const queryIndex = connectionData.queries.findIndex((q: SavedQuery) => q.uid === args.queryUid);
+         if (queryIndex === -1) return;
+
+         const existingQuery = connectionData.queries[queryIndex];
+
+         const updatedQuery: SavedQuery = {
+            ...existingQuery,
+            name: args.name !== undefined ? args.name : existingQuery.name,
+            sql: args.sql !== undefined ? args.sql : existingQuery.sql,
+            folderId: args.folderId !== undefined ? args.folderId : existingQuery.folderId,
+            schema: args.schema !== undefined ? args.schema : existingQuery.schema,
+            database: args.database !== undefined ? args.database : existingQuery.database,
+            updatedAt: new Date().toISOString()
+         };
+
+         connectionData.queries[queryIndex] = updatedQuery;
+
+         this._persist();
+      },
+      renameQuery (args: { connectionUid: string; queryUid: string; name: string }): void {
+         this.updateQuery({ connectionUid: args.connectionUid, queryUid: args.queryUid, name: args.name });
+      },
+      deleteQuery (args: { connectionUid: string; queryUid: string }): void {
+         const connectionData = this.queriesByConnection[args.connectionUid];
+         if (!connectionData) return;
+
+         connectionData.queries = connectionData.queries.filter((q: SavedQuery) => q.uid !== args.queryUid);
+         this._persist();
+      },
+      duplicateQuery (args: { connectionUid: string; queryUid: string }): SavedQuery | undefined {
+         const query = this.getQueryById(args.connectionUid, args.queryUid);
+         if (!query) return undefined;
+
+         return this.addQuery({
+            connectionUid: args.connectionUid,
+            name: `${query.name} (copy)`,
+            sql: query.sql,
+            folderId: query.folderId,
+            schema: query.schema,
+            database: query.database
+         });
+      },
+      moveQueryToFolder (args: { connectionUid: string; queryUid: string; folderId: string | null }): void {
+         this.updateQuery({ connectionUid: args.connectionUid, queryUid: args.queryUid, folderId: args.folderId });
+      },
+      addFolder (args: { connectionUid: string; name: string; parentId?: string }): QueryFolder {
+         this._ensureConnectionData(args.connectionUid);
+
+         const newFolder: QueryFolder = {
+            uid: uidGen('QF'),
+            name: args.name,
+            connectionUid: args.connectionUid,
+            parentId: args.parentId ?? null,
+            isExpanded: false,
+            createdAt: new Date().toISOString()
+         };
+
+         this.queriesByConnection[args.connectionUid].folders.push(newFolder);
+         this._persist();
+         return newFolder;
+      },
+      renameFolder (args: { connectionUid: string; folderUid: string; name: string }): void {
+         const connectionData = this.queriesByConnection[args.connectionUid];
+         if (!connectionData) return;
+
+         const folder = connectionData.folders.find((f: QueryFolder) => f.uid === args.folderUid);
+         if (folder) {
+            folder.name = args.name;
+            this._persist();
+         }
+      },
+      toggleFolderExpanded (args: { connectionUid: string; folderUid: string }): void {
+         const connectionData = this.queriesByConnection[args.connectionUid];
+         if (!connectionData) return;
+
+         const folder = connectionData.folders.find((f: QueryFolder) => f.uid === args.folderUid);
+         if (folder) {
+            folder.isExpanded = !folder.isExpanded;
+            this._persist();
+         }
+      },
+      deleteFolder (args: { connectionUid: string; folderUid: string; deleteContents?: boolean }): void {
+         const connectionData = this.queriesByConnection[args.connectionUid];
+         if (!connectionData) return;
+
+         if (args.deleteContents) {
+            connectionData.queries = connectionData.queries.filter((q: SavedQuery) => q.folderId !== args.folderUid);
+
+            const deleteSubfolders = (parentId: string) => {
+               const subfolders = connectionData.folders.filter((f: QueryFolder) => f.parentId === parentId);
+               for (const subfolder of subfolders) {
+                  connectionData.queries = connectionData.queries.filter((q: SavedQuery) => q.folderId !== subfolder.uid);
+                  deleteSubfolders(subfolder.uid);
+               }
+               connectionData.folders = connectionData.folders.filter((f: QueryFolder) => f.parentId !== parentId);
+            };
+            deleteSubfolders(args.folderUid);
+         }
+         else {
+            const folder = connectionData.folders.find((f: QueryFolder) => f.uid === args.folderUid);
+            const parentId = folder?.parentId ?? null;
+            connectionData.queries = connectionData.queries.map((q: SavedQuery) => {
+               if (q.folderId === args.folderUid) return { ...q, folderId: parentId };
+               return q;
+            });
+
+            connectionData.folders = connectionData.folders.map((f: QueryFolder) => {
+               if (f.parentId === args.folderUid) return { ...f, parentId };
+               return f;
+            });
+         }
+
+         connectionData.folders = connectionData.folders.filter((f: QueryFolder) => f.uid !== args.folderUid);
+         this._persist();
+      },
+      getFolderDepth (connectionUid: string, folderId: string): number {
+         let depth = 0;
+         let currentId: string | null = folderId;
+
+         while (currentId) {
+            const folder = this.getFolderById(connectionUid, currentId);
+            if (!folder) break;
+            currentId = folder.parentId;
+            depth++;
+         }
+
+         return depth;
+      }
+   }
+});

--- a/src/renderer/stores/workspaces.ts
+++ b/src/renderer/stores/workspaces.ts
@@ -761,8 +761,8 @@ export const useWorkspacesStore = defineStore('workspaces', {
                this.selectTab({ uid, tab: workspace.tabs[workspace.tabs.length - 1].uid });
          }
       },
-      updateTabContent ({ uid, tab, type, schema, content, elementName, filePath }: WorkspaceTab) {
-         this._replaceTab({ uid, tab, type, schema, content, elementName, filePath });
+      updateTabContent ({ uid, tab, type, schema, content, elementName, elementType, filePath }: WorkspaceTab) {
+         this._replaceTab({ uid, tab, type, schema, content, elementName, elementType, filePath });
       },
       renameTabs ({ uid, schema, elementName, elementNewName }: WorkspaceTab) {
          this.workspaces = (this.workspaces as Workspace[]).map(workspace => {


### PR DESCRIPTION
## PR Description

### Summary
Adds an Insomnia-inspired saved queries system that automatically persists query tabs and organizes them in a dedicated sidebar panel.

### Features
- **Auto-save**: Query content is automatically saved as you type with debounced updates
- **Folder organization**: Create nested folders (up to 3 levels) to organize queries
- **Inline rename**: Double-click to rename queries or folders directly in the sidebar
- **Context menus**: Right-click for actions like duplicate, move to folder, and delete
- **Tab sync**: Renaming a saved query updates the corresponding open tab title
- **Per-connection storage**: Queries are scoped to their database connection

### Screenshots
<img width="312" height="276" alt="image" src="https://github.com/user-attachments/assets/38e0ad73-bf45-41b9-b423-0783d8163feb" />