### PR TITLE
feat: add 'run query at cursor' shortcut and functionality

### DIFF
--- a/src/common/shortcuts.ts
+++ b/src/common/shortcuts.ts
@@ -1,5 +1,6 @@
 export const shortcutEvents: Record<string, { i18n: string; i18nParam?: string | number; context?: 'tab' | 'main' }> = {
    'run-or-reload': { i18n: 'application.runOrReload', context: 'tab' },
+   'run-query-at-cursor': { i18n: 'application.runQueryAtCursor', context: 'tab' },
    'open-new-tab': { i18n: 'application.openNewTab', context: 'tab' },
    'close-tab': { i18n: 'application.closeTab', context: 'tab' },
    'format-query': { i18n: 'database.formatQuery', context: 'tab' },
@@ -41,6 +42,11 @@ const shortcuts: ShortcutRecord[] = [
    {
       event: 'run-or-reload',
       keys: ['F5'],
+      os: ['darwin', 'linux', 'win32']
+   },
+   {
+      event: 'run-query-at-cursor',
+      keys: ['CommandOrControl+Enter'],
       os: ['darwin', 'linux', 'win32']
    },
    {

--- a/src/renderer/components/WorkspaceTabQuery.vue
+++ b/src/renderer/components/WorkspaceTabQuery.vue
@@ -276,7 +276,8 @@
 <script setup lang="ts">
 import { getCurrentWindow, Menu } from '@electron/remote';
 import { Ace } from 'ace-builds';
-import { ConnectionParams } from 'common/interfaces/antares';
+import { ClientCode, ConnectionParams } from 'common/interfaces/antares';
+import { querySplitter } from 'common/libs/sqlUtils';
 import { uidGen } from 'common/libs/uidGen';
 import { ipcRenderer } from 'electron';
 import { storeToRefs } from 'pinia';
@@ -371,6 +372,37 @@ const hasAffected = computed(() => affectedCount.value || (!resultsCount.value &
 const isChanged = computed(() => {
    return filePath.value && lastSavedQuery.value !== query.value;
 });
+
+const getCurrentQueryAtCursor = () => {
+   if (!queryEditor.value?.editor) return '';
+
+   const editorInstance = queryEditor.value.editor;
+   const session = editorInstance.session as Ace.EditSession & {
+      doc: {
+         positionToIndex: (position: Ace.Point) => number;
+      };
+   };
+   const cursorPosition = editorInstance.getCursorPosition();
+   const cursorIndex = session.doc.positionToIndex(cursorPosition);
+   const allQueries = querySplitter(query.value, workspace.value.client as ClientCode);
+
+   if (!allQueries.length) return '';
+
+   let currentStart = 0;
+   for (const localQuery of allQueries) {
+      const localIndex = query.value.indexOf(localQuery, currentStart);
+      if (localIndex === -1) continue;
+
+      const localEnd = localIndex + localQuery.length;
+      const isInsideQuery = cursorIndex >= localIndex && cursorIndex <= localEnd;
+      if (isInsideQuery)
+         return localQuery;
+
+      currentStart = localEnd;
+   }
+
+   return '';
+};
 
 watch(query, (val) => {
    clearTimeout(debounceTimeout.value);
@@ -674,6 +706,15 @@ const reloadListener = () => {
       runQuery(query.value);
 };
 
+const runQueryAtCursorListener = () => {
+   const hasModalOpen = !!document.querySelectorAll('.modal.active').length;
+   if (!props.isSelected || hasModalOpen) return;
+
+   const queryAtCursor = getCurrentQueryAtCursor();
+   if (queryAtCursor)
+      runQuery(queryAtCursor);
+};
+
 const formatListener = () => {
    const hasModalOpen = !!document.querySelectorAll('.modal.active').length;
    if (props.isSelected && !hasModalOpen)
@@ -777,6 +818,7 @@ onMounted(() => {
    const localResizer = resizer.value;
 
    ipcRenderer.on('run-or-reload', reloadListener);
+   ipcRenderer.on('run-query-at-cursor', runQueryAtCursorListener);
    ipcRenderer.on('format-query', formatListener);
    ipcRenderer.on('kill-query', killQueryListener);
    ipcRenderer.on('clear-query', clearQueryListener);
@@ -869,6 +911,7 @@ onBeforeUnmount(() => {
    Schema.destroyConnectionToCommit(params);
 
    ipcRenderer.removeListener('run-or-reload', reloadListener);
+   ipcRenderer.removeListener('run-query-at-cursor', runQueryAtCursorListener);
    ipcRenderer.removeListener('format-query', formatListener);
    ipcRenderer.removeListener('kill-query', killQueryListener);
    ipcRenderer.removeListener('clear-query', clearQueryListener);

--- a/src/renderer/i18n/en-US.ts
+++ b/src/renderer/i18n/en-US.ts
@@ -367,6 +367,7 @@ export const enUS = {
       openAllConnections: 'Open all connections',
       openSettings: 'Open settings',
       runOrReload: 'Run or reload',
+      runQueryAtCursor: 'Run query at cursor',
       openFilter: 'Open filter',
       nextResultsPage: 'Next results page',
       previousResultsPage: 'Previous results page',

--- a/src/renderer/i18n/pt-BR.ts
+++ b/src/renderer/i18n/pt-BR.ts
@@ -329,6 +329,7 @@ export const ptBR = {
       openSettings: 'Abrir Configurações',
       openScratchpad: 'Abrir scratchpad',
       runOrReload: 'Executar ou recarregar',
+      runQueryAtCursor: 'Executar consulta da linha do cursor',
       openFilter: 'Abrir Filtro',
       nextResultsPage: 'Próxima página de resultados',
       previousResultsPage: 'Página de resultados anterior',


### PR DESCRIPTION
## PR Description

### Summary
This PR introduces the ability to execute the specific SQL query located at the cursor's current position. This addresses the need for "statement-aware" query execution, allowing users to easily run individual statements within a multi-query tab without needing to highlight the text manually.

### Features
* **Statement-aware execution**: Automatically identifies and extracts the SQL statement currently under the text cursor using the editor's position and the `querySplitter`.
* **New shortcut**: Implemented the `CommandOrControl+Enter` shortcut to trigger the new "Run query at cursor" action.
* **i18n support**: Added localization strings for the new shortcut event in English (`en-US`) and Portuguese (`pt-BR`).

### Related Issues
Closes #866
Closes #410

### Screenshots
<img width="657" height="269" alt="Captura de Tela 2026-04-21 às 13 59 26" src="https://github.com/user-attachments/assets/0a20233d-c822-4640-a381-4413c8bdc493" />
