### PR TITLE
fix: Saved Connections Lost 

### DIFF
--- a/src/main/ipc-handlers/application.ts
+++ b/src/main/ipc-handlers/application.ts
@@ -17,35 +17,41 @@ export default () => {
    });
 
    ipcMain.on('set-key', (event, key) => {
-      if (safeStorage.isEncryptionAvailable()) {
-         const sessionStore = new Store({
-            name: 'session',
-            fileExtension: ''
-         });
-         const encrypted = safeStorage.encryptString(key);
-         sessionStore.set('key', encrypted);
-         event.returnValue = true;
-      }
-   });
-
-   ipcMain.on('get-key', (event) => {
-      if (!safeStorage.isEncryptionAvailable()) {
-         event.returnValue = false;
-         return;
-      }
       const sessionStore = new Store({
          name: 'session',
          fileExtension: ''
       });
 
-      try {
-         const encrypted = sessionStore.get('key') as string;
-         const key = safeStorage.decryptString(Buffer.from(encrypted, 'utf-8'));
-         event.returnValue = key;
+      if (safeStorage.isEncryptionAvailable()) {
+         const encrypted = safeStorage.encryptString(key);
+         sessionStore.set('key', encrypted);
       }
-      catch (error) {
-         event.returnValue = false;
+      else
+         sessionStore.set('key', key);
+
+      event.returnValue = true;
+   });
+
+   ipcMain.on('get-key', (event) => {
+      const sessionStore = new Store({
+         name: 'session',
+         fileExtension: ''
+      });
+
+      if (safeStorage.isEncryptionAvailable()) {
+         try {
+            const encrypted = sessionStore.get('key') as string;
+            const key = safeStorage.decryptString(Buffer.from(encrypted, 'utf-8'));
+            event.returnValue = key;
+            return;
+         }
+         catch {
+            // Fall through to unencrypted fallback
+         }
       }
+
+      const key = sessionStore.get('key') as string | undefined;
+      event.returnValue = key || false;
    });
 
    ipcMain.handle('show-open-dialog', (event, options) => {

--- a/src/renderer/stores/connections.ts
+++ b/src/renderer/stores/connections.ts
@@ -3,14 +3,13 @@ import { uidGen } from 'common/libs/uidGen';
 import * as crypto from 'crypto';
 import { ipcRenderer } from 'electron';
 import * as Store from 'electron-store';
+import * as fs from 'fs';
 import { defineStore } from 'pinia';
 
 import { i18n } from '@/i18n';
 import { useWorkspacesStore } from '@/stores/workspaces';
 
 import { useNotificationsStore } from './notifications';
-
-let key = localStorage.getItem('key');
 
 export interface SidebarElement {
    isFolder: boolean;
@@ -25,28 +24,57 @@ export interface SidebarElement {
 
 export interface CustomIcon {base64: string; uid: string}
 
-if (!key) { // If no key in local storage
-   const storedKey = ipcRenderer.sendSync('get-key');// Ask for key stored on disk
-
-   if (!storedKey) { // If not stored key on disk
-      const newKey = crypto.randomBytes(16).toString('hex');
-      localStorage.setItem('key', newKey);
-      ipcRenderer.send('set-key', newKey);
-      key = newKey;
+function getEncryptionKey (): string {
+   const cachedKey = localStorage.getItem('key');
+   if (cachedKey) {
+      ipcRenderer.send('set-key', cachedKey);
+      return cachedKey;
    }
-   else {
+
+   const storedKey = ipcRenderer.sendSync('get-key');
+   if (storedKey) {
       localStorage.setItem('key', storedKey);
-      key = storedKey;
+      return storedKey;
+   }
+
+   const newKey = crypto.randomBytes(16).toString('hex');
+   localStorage.setItem('key', newKey);
+   ipcRenderer.send('set-key', newKey);
+   return newKey;
+}
+
+function createPersistentStore (key: string) {
+   try {
+      const store = new Store({
+         name: 'connections',
+         encryptionKey: key,
+         clearInvalidConfig: true
+      });
+      store.get('connections');
+      return store;
+   }
+   catch {
+      try {
+         const corruptStore = new Store({
+            name: 'connections',
+            encryptionKey: key,
+            clearInvalidConfig: false
+         });
+         const configPath = (corruptStore as any).path;
+         if (typeof configPath === 'string' && fs.existsSync(configPath))
+            fs.copyFileSync(configPath, configPath + '.corrupt');
+      }
+      catch {}
+
+      return new Store({
+         name: 'connections',
+         encryptionKey: key,
+         clearInvalidConfig: true
+      });
    }
 }
-else
-   ipcRenderer.send('set-key', key);
 
-const persistentStore = new Store({
-   name: 'connections',
-   encryptionKey: key,
-   clearInvalidConfig: true
-});
+const persistentStore = createPersistentStore(getEncryptionKey());
 
 export const useConnectionsStore = defineStore('connections', {
    state: () => ({


### PR DESCRIPTION
[Issue #913 All Saved Connections lost when opening a second window](https://github.com/antares-sql/antares/issues/913)

Root cause
The connections store uses electron-store with encryption to protect passwords. The encryption key was managed through safeStorage (Electron's OS keychain API). On Flatpak/Linux where safeStorage is unavailable, the key couldn't be persisted:
- set-key handler silently dropped the key when safeStorage was unavailable
- get-key returned false when safeStorage was unavailable
- A second window or app restart would generate a different encryption key
- clearInvalidConfig: true on the store would then silently delete the encrypted file when decryption failed with the wrong key permanent data loss



Changes made
src/main/ipc-handlers/application.ts (main process key persistence):
- set-key: Always persists the key now. If safeStorage is available, encrypts it; otherwise stores the key as plain text in the session store (same directory, same file-system protection).
- get-key: Always reads from the store. Tries safeStorage decryption first, falls back to raw key read if unavailable or decryption fails.

src/renderer/stores/connections.ts (renderer key retrieval + data safety):
- Refactored key retrieval into getEncryptionKey() always uses the main process as the source of truth, with localStorage as a fast cache.
- Wrapped store creation in createPersistentStore() if the store file can't be decrypted (e.g., real corruption), it backs up the file with a .corrupt extension before resetting, rather than silently deleting it.


Result
- Second windows and app restarts now always get the same encryption key
- clearInvalidConfig: true can no longer trigger on key mismatch only on genuine file corruption
- In the worst case, a backup file is preserved for manual recovery